### PR TITLE
fix 'send to other' link

### DIFF
--- a/app/controllers/spree/email_sender_controller.rb
+++ b/app/controllers/spree/email_sender_controller.rb
@@ -18,7 +18,7 @@ class Spree::EmailSenderController < Spree::BaseController
           captcha_passed = !Spree::Captcha::Config[:use_captcha] || verify_recaptcha(:private_key => Spree::Captcha::Config[:private_key])
           if @mail_to_friend.valid? && captcha_passed
             flash[:notice] = I18n.t('email_to_friend.mail_sent_to', :email => @mail_to_friend.recipient_email).html_safe
-            flash[:notice] << ActionController::Base.helpers.link_to(I18n.t('email_to_friend.send_to_other'), email_to_friend_path(@object.class.name.downcase, @object)).html_safe
+            flash[:notice] << ActionController::Base.helpers.link_to(I18n.t('email_to_friend.send_to_other'), email_to_friend_path(@object.class.name.split("::").last.downcase, @object)).html_safe
 
             send_message(@object, @mail_to_friend)
 


### PR DESCRIPTION
This was broken for Spree 1.0.3; fix is from an email on the spree-user list from samt; I had the same problem so added this pull request.  His email:

---

Got an issue with spree_email_to_friend, the following code:

@object.class.name.downcase in the file: email_sender_controller.rb returned "spree::product", which meant the that url was incorrect as it should just be "product".

My fix was:

@object.class.name.split("::").last.downcase
