### PR TITLE
change :mails_from preference

### DIFF
--- a/app/mailers/spree/to_friend_mailer.rb
+++ b/app/mailers/spree/to_friend_mailer.rb
@@ -1,5 +1,5 @@
 class Spree::ToFriendMailer < ActionMailer::Base
-  default :from => Spree::Config[:mails_from]
+  default :from => Spree::MailMethod.current.preferred_mails_from
 
   def mail_to_friend(object, mail)
     @object = object


### PR DESCRIPTION
Using Spree::Config[:mails_from] doesn't seem to work on Spree 1.0.3; this change takes care of that, so the mails can now be sent.  

Ref. issue #9
