### PR TITLE
remove disabled=>false to allow overriding later

### DIFF
--- a/app/overrides/add_email_to_friend_link_to_products.rb
+++ b/app/overrides/add_email_to_friend_link_to_products.rb
@@ -3,5 +3,4 @@ Deface::Override.new(:virtual_path => "spree/products/show",
                      :insert_bottom => "[data-hook='product_description'], #product_description[data-hook]",
                      :text => "<p class=\"email_to_friend\">
         <%= link_to t('email_to_friend.send_to_friend'), email_to_friend_url('product', @product) %>
-    </p>",
-                     :disabled => false)
+    </p>")


### PR DESCRIPTION
Removed :disabled => false from the override.  When it's there (and false), you sometimes cannot override this override in your app with :disabled => true.  Removing it has no adverse effect, and corrects the problem.

Note that I was able to override it in development, but not in production. Not sure why; might be related to this issue on deface: https://github.com/railsdog/deface/issues/26

With this change, seems to work in all environments.
