### PR TITLE
Fix user reference in send_mail function.

### DIFF
--- a/app/controllers/spree/email_sender_controller.rb
+++ b/app/controllers/spree/email_sender_controller.rb
@@ -6,7 +6,7 @@ class Spree::EmailSenderController < Spree::BaseController
 
   def send_mail
     if request.get?
-      @mail_to_friend = Spree::MailToFriend.new(:sender_email => current_user.try(:email))
+      @mail_to_friend = Spree::MailToFriend.new(:sender_email => current_spree_user.try(:email))
     else
       mail_to_friend
     end


### PR DESCRIPTION
Spree::EmailSenderController.send_mail function raises undefined 'current_user' since commit 07b486e997 in spree/spree_auth_devise. This commit should be applied to master branch too.
