### PR TITLE
Add additional spree helpers to resolve NoMethodError

### DIFF
--- a/app/controllers/spree/email_sender_controller.rb
+++ b/app/controllers/spree/email_sender_controller.rb
@@ -1,5 +1,7 @@
 class Spree::EmailSenderController < Spree::BaseController
 
+  helper Spree::StoreHelper
+  helper Spree::BaseHelper
   include Spree::Core::ControllerHelpers::Order
 
   before_filter :find_object


### PR DESCRIPTION
- Resolves the following error : NoMethodError - undefined method `store_menu?' for #<#Class:0x007fd10a8e3c20:0x007fd10a8eaca0>:
