### PR TITLE
Defining :original for add_captcha_admin_option

### DIFF
--- a/app/overrides/add_captcha_settings_to_admin_configurations_menu.rb
+++ b/app/overrides/add_captcha_settings_to_admin_configurations_menu.rb
@@ -2,4 +2,5 @@ Deface::Override.new(:virtual_path => "spree/admin/shared/_configuration_menu",
                      :name => "add_captcha_admin_option",
                      :insert_bottom => "[data-hook='admin_configurations_sidebar_menu']",
                      :text => "<%= configurations_sidebar_menu_item t('captcha.captcha_settings'), edit_admin_captcha_settings_path %>",
-                     :disabled => false)
+                     :disabled => false,
+                     :original => "79c014804a1949e83a2a83e78e09ed66e63027cf")


### PR DESCRIPTION
responding to warning:

[1;32mDeface:[0m 'add_captcha_admin_option' matched 1 times with '[data-hook='admin_configurations_sidebar_menu']'
[1;32mDeface: [WARNING][0m No :original defined for 'add_captcha_admin_option', you should change its definition to include:
 :original => '79c014804a1949e83a2a83e78e09ed66e63027cf'
