### PR TITLE
Route now accepts get/post

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Spree::Core::Engine.routes.draw do
 
-  post "/email_to_friend/:type/:id" => 'email_sender#send_mail', as: :email_to_friend
+  match "/email_to_friend/:type/:id" => 'email_sender#send_mail', as: :email_to_friend, via: [:get, :post]
 
   namespace :admin do
     resource :captcha_settings


### PR DESCRIPTION
`Spree::EmailSenderController` expects either a get or post. Previous change locked it to just a post.
