### PR TITLE
Render template based on object type

### DIFF
--- a/app/views/spree/products/_mail_to_friend.text.erb
+++ b/app/views/spree/products/_mail_to_friend.text.erb
@@ -2,7 +2,7 @@
 
 I think you would like this item:
 
-  * <%= product.name %>
+  * <%= object.name %>
 
 <% unless mail.message.blank? -%>
 <%= mail.message %>
@@ -10,7 +10,7 @@ I think you would like this item:
 
 <%= mail.sender_name %>
 
-Click the link below to view the <%= product.name %> page.
-<%= spree.product_url(product) %>
+Click the link below to view the <%= object.name %> page.
+<%= spree.product_url(object) %>
 
 For more online shopping, visit <%= spree.products_url %>

--- a/app/views/spree/to_friend_mailer/mail_to_friend.text.erb
+++ b/app/views/spree/to_friend_mailer/mail_to_friend.text.erb
@@ -1,3 +1,3 @@
-<% object_sym = @object.class.name.downcase %>
-<%= render :partial => "spree/products/mail_to_friend", 
-           :locals => {:product => @object, :mail => @mail} %>
+<% object_sym = @object.class.name.tableize %>
+<%= render :partial => "#{object_sym}/mail_to_friend",
+           :locals => {:object => @object, :mail => @mail} %>


### PR DESCRIPTION
Template rendering is currently hard linked to products. This allows template rendering for other models like `Spree::WishList`.
