### PR TITLE
Find by id is last attempt

### DIFF
--- a/app/controllers/spree/email_sender_controller.rb
+++ b/app/controllers/spree/email_sender_controller.rb
@@ -45,13 +45,17 @@ class Spree::EmailSenderController < Spree::StoreController
     def find_object
       class_name = "Spree::#{(params[:type].titleize)}".constantize
       return false if params[:id].blank?
-      @object = class_name.find_by_id(params[:id])
+
       if class_name.respond_to?('find_by_permalink')
         @object ||= class_name.find_by_permalink(params[:id])
       end
       if class_name.respond_to?('get_by_param')
         @object ||= class_name.get_by_param(params[:id])
       end
+
+      # Final attempt to load by id.
+      @object ||= class_name.find_by_id(params[:id])
+
       # Display 404 page if object is not found.
       raise ActiveRecord::RecordNotFound if @object.nil?
     end


### PR DESCRIPTION
Find by id is the last method attempted.

`Spree::Wishlist` use an `access_hash` such as `8dbbada...`, but when passed to `find_object` it was causing `find_by_id(8)` to be called instead of `find_by_param("8dbbada...")`.
