### PR TITLE
removed annoying space from "sender email" field + tests fixed

### DIFF
--- a/app/mailers/spree/to_friend_mailer.rb
+++ b/app/mailers/spree/to_friend_mailer.rb
@@ -1,5 +1,5 @@
 class Spree::ToFriendMailer < ActionMailer::Base
-  default from: ''
+  default from: Spree::Store.current.mail_from_address || ''
 
   def mail_to_friend(object, mail)
     @object = object

--- a/app/mailers/spree/to_friend_mailer.rb
+++ b/app/mailers/spree/to_friend_mailer.rb
@@ -1,5 +1,5 @@
 class Spree::ToFriendMailer < ActionMailer::Base
-  default from: Spree::Config[:mails_from] || ''
+  default from: ''
 
   def mail_to_friend(object, mail)
     @object = object

--- a/app/models/spree/mail_to_friend.rb
+++ b/app/models/spree/mail_to_friend.rb
@@ -12,14 +12,14 @@ class Spree::MailToFriend
   validates :invalid_recipients, length: { maximum: 0, message: Spree.t(:invalid_recipients, scope: :validation) }
 
   def initialize(opts = {})
-    @sender_email = opts[:sender_email] || ' '
-    @sender_name  = opts[:sender_name]  || @sender_email.split('@', 2)[0].titleize
+    @sender_email = opts[:sender_email] || ''
+    @sender_name  = opts[:sender_name]  || (@sender_email.split('@', 2)[0] || '').titleize
     @subject      = opts[:subject]      || Spree.t(:sender_subject, scope: :email_to_friend, sender_name: @sender_name, site: site_url)
 
     @recipients = []
     @invalid_recipients = []
 
-    addresses = (opts[:recipient_email] || '').gsub(';', ',').gsub(/\s/, '')
+    addresses = (opts[:recipient_email] || '').tr(';', ',').gsub(/\s/, '')
     addresses.split(',').each do |address|
       if address =~ EMAILREGEX
         @recipients << address

--- a/spec/factories/mail_factory.rb
+++ b/spec/factories/mail_factory.rb
@@ -1,15 +1,15 @@
 FactoryGirl.define do
   factory :mail, class: Spree::MailToFriend do
     host               'localhost'
-    sender_name        { Faker::Name.name }
-    sender_email       { Faker::Internet.email(sender_name) }
-    recipient_name     { Faker::Name.name }
-    recipient_email    { Faker::Internet.email(recipient_name) }
+    sender_name        { FFaker::Name.name }
+    sender_email       { FFaker::Internet.email(sender_name) }
+    recipient_name     { FFaker::Name.name }
+    recipient_email    { FFaker::Internet.email(recipient_name) }
 
     subject            'Check this out!'
     message            'Its totally awesome..'
 
-    recipients         { Array(1..4).sample.times.map { Faker::Internet.email } }
+    recipients         { Array(1..4).sample.times.map { FFaker::Internet.email } }
     invalid_recipients []
   end
 end

--- a/spec/features/email_sender_spec.rb
+++ b/spec/features/email_sender_spec.rb
@@ -6,20 +6,21 @@ RSpec.feature 'Email to friend', :js do
     visit spree.product_path(product)
     expect(page).to have_text product.name
     expect(page).to have_link 'Email a friend'
-    click_link 'Email a friend'
-  end
-
-  scenario 'throw error on empty form submission' do
-    click_button 'Tell your friend!'
-    expect(page).to have_text 'There were problems with the following fields:'
   end
 
   context 'without captcha' do
     background do
       Spree::Captcha::Config.use_captcha = false
+      click_link 'Email a friend'
+    end
+
+    scenario 'throw error on empty form submission' do
+      click_button 'Tell your friend!'
+      expect(page).to have_text 'There were problems with the following fields:'
     end
 
     scenario 'even a robot can send email to friend' do
+      expect(find_field('mail_to_friend_sender_email').value).to eq ''
       fill_in_form_with mail
       click_button 'Tell your friend!'
       expect(page).to have_text "Mail sent to #{mail.recipients.first}"
@@ -29,12 +30,12 @@ RSpec.feature 'Email to friend', :js do
   context 'with captcha' do
     background do
       Spree::Captcha::Config.use_captcha = true
+      click_link 'Email a friend'
     end
 
     scenario 'only human can send email to friend' do
       fill_in_form_with mail
       click_button 'Tell your friend!'
-      pending 'It bypass captcha..'
       expect(page).not_to have_text "Mail sent to #{mail.recipients.first}"
     end
   end

--- a/spec/support/captcha.rb
+++ b/spec/support/captcha.rb
@@ -1,0 +1,9 @@
+RSpec.configure do |config|
+
+  Recaptcha.configuration.skip_verify_env.delete("test")
+
+  config.before do
+    # reset captcha config
+    Spree::Captcha::Config.set(Spree::Captcha::Config.default_preferences)
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,7 +4,7 @@ require 'capybara/poltergeist'
 
 RSpec.configure do |config|
   Capybara.javascript_driver = :poltergeist
-  
+
   config.before(:each, :js) do
     if Capybara.javascript_driver == :selenium
       page.driver.browser.manage.window.maximize

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,7 +4,7 @@ require 'capybara/poltergeist'
 
 RSpec.configure do |config|
   Capybara.javascript_driver = :poltergeist
-
+  
   config.before(:each, :js) do
     if Capybara.javascript_driver == :selenium
       page.driver.browser.manage.window.maximize


### PR DESCRIPTION
Removed init whitespace from "sender email" field. 

This whitespace was default value in input, so user doesn't have to delete it before writing his email address.